### PR TITLE
Update Node Version 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   head-ref:
     description: 'ref of the head commit to compare (mainly for testing the action)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: blue


### PR DESCRIPTION
Updating Node version from 12 to 16 since Node.js 12 actions are deprecated and we are getting waring in bct-device-standard-messages repository

PR link :- https://github.com/TBCTSystems/bct-common-device-standard-messages/pull/348