### PR TITLE
set-ouput warnings during CI runs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1611,7 +1611,6 @@ function run() {
             for (const r of rules) {
                 const changed = evaluateRule(r, changedFiles) ? 'true' : 'false';
                 core.debug(`rule: ${r.name}, changed: ${changed}`);
-                // core.setOutput(r.name, changed);
                 core.setOutputUpdated(r.name, changed);
             }
         }
@@ -2061,7 +2060,7 @@ function escape(s) {
 }
 
 ///////
-////     Setting output using Environment Files
+////     Setting outputs using Environment Files
 ///////
 
 function issueSetOutputCommand(envName, envValue) {
@@ -2081,7 +2080,6 @@ class OutputCommand {
       this.envValue = envValue;
   }
   toString() {
-    // let cmdStr = `"${this.envName}=${this.envValue}" >> $GITHUB_OUTPUT`;
     let cmdStr = `"${this.envName}=${this.envValue}"`;
     return cmdStr;
   }


### PR DESCRIPTION
The changes on this PR will make use of Environment Files instead of set-output commands. The `set-output` command is deprecated and will be disabled soon. these changes are necessary to prevent run fails in the future. 

Create Task : https://tbct-jira.valiantys.net/browse/ATL-16128
Review Task:  https://tbct-jira.valiantys.net/browse/ATL-16130
